### PR TITLE
Added rounding function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,29 @@
 # Math Variable for Google Tag Manager Server Container
 
-TBD
+A custom variable template for the GTM Server container that performs basic mathematical operations between two input values. Now includes optional result rounding.
+
+## Features
+
+- Supports addition, subtraction, multiplication, and division
+- Accepts numeric inputs or string representations of numbers
+- Optional rounding to a configurable number of decimal places
+
+## Usage
+
+1. Select a math operation: Add, Subtract, Multiply, or Divide
+2. Enter two numeric input values
+3. Enable "Round result" to round the output
+4. Specify the number of decimal places to round to (defaults to `2` if left empty)
+
+## 📦 Installation
+
+Import the `template.tpl` file into your GTM Server container under **Templates** → **New** → **Import**.
 
 ## Open Source
 
 Initial development was done by [Lars Friis](https://www.linkedin.com/in/lars-friis/).
 
 Math Variable for GTM Server Side is developing and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.
+
+
+

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A custom variable template for the GTM Server container that performs basic math
 3. Enable "Round result" to round the output
 4. Specify the number of decimal places to round to (defaults to `2` if left empty)
 
-## 📦 Installation
+## Installation
 
 Import the `template.tpl` file into your GTM Server container under **Templates** → **New** → **Import**.
 

--- a/template.js
+++ b/template.js
@@ -1,25 +1,58 @@
 const makeNumber = require('makeNumber');
 const getType = require('getType');
-const type = data.type;
 
-if (data.number1.length <= 0 || data.number2.length <= 0 ) return undefined;
+const type = data.type;
+const roundResult = !!data.roundResult;
+
+let decimals = makeNumber(data.decimals);
+if (getType(decimals) !== 'number' || decimals !== decimals || decimals < 0) {
+  decimals = 2;
+}
+
+if (data.number1.length <= 0 || data.number2.length <= 0) return undefined;
 
 const number1 = makeNumber(data.number1);
 const number2 = makeNumber(data.number2);
 
-if (getType(number1) !== 'number' || getType(number2) !== 'number' || number1 !== number1 || number2 !== number2) {
+if (
+  getType(number1) !== 'number' ||
+  getType(number2) !== 'number' ||
+  number1 !== number1 ||
+  number2 !== number2
+) {
   return undefined;
 }
 
+let result;
+
 switch (type) {
   case 'multiply':
-    return number1 * number2;
+    result = number1 * number2;
+    break;
   case 'divide':
-    return number2 !== 0 ? number1 / number2 : undefined;
+    result = number2 !== 0 ? number1 / number2 : undefined;
+    break;
   case 'add':
-    return number1 + number2;
+    result = number1 + number2;
+    break;
   case 'subtract':
-    return number1 - number2;
+    result = number1 - number2;
+    break;
   default:
     return undefined;
 }
+
+if (typeof result === 'number' && roundResult) {
+  let factor = 1;
+  let i = 0;
+  while (i < decimals) {
+    factor = factor * 10;
+    i = i + 1;
+  }
+
+  result = (result * factor + 0.5);
+  result = result - (result % 1);
+  result = result / factor;
+}
+
+return result;

--- a/template.tpl
+++ b/template.tpl
@@ -1,4 +1,4 @@
-﻿___TERMS_OF_SERVICE___
+___TERMS_OF_SERVICE___
 
 By creating or modifying this file you agree to Google Tag Manager's Community
 Template Gallery Developer Terms of Service available at
@@ -70,7 +70,33 @@ ___TEMPLATE_PARAMETERS___
         "type": "NON_EMPTY"
       }
     ]
-  }
+  },
+  {
+    "type": "CHECKBOX",
+    "name": "roundResult",
+    "displayName": "Round result",
+    "checkboxText": "Round",
+    "simpleValueType": true
+  },
+  {
+  "type": "TEXT",
+  "name": "decimals",
+  "displayName": "Decimal places",
+  "simpleValueType": true,
+  "help": "Number of decimal places to round to (e.g., 2)",
+  "valueValidators": [
+    {
+      "type": "NON_NEGATIVE_NUMBER"
+    }
+  ],
+  "visibilityConditions": [
+    {
+      "parameterName": "roundResult",
+      "predicateType": "EQUALS",
+      "value": true
+    }
+  ]
+}
 ]
 
 


### PR DESCRIPTION
This PR introduces an optional “Round result” checkbox with a configurable number of decimal places to the math-variable GTM template.

Changes

- Added a checkbox to enable rounding
- Added a text input to specify the number of decimal places (default: 2)
- Implemented rounding using GTM-safe logic (no MathRound, Math.pow, or unsupported functions)

Example use case

Useful when mathematical results like 2.49 * 0.18 need to be rounded to 0.45 instead of 0.44820000000000004.

Let me know if any adjustments are needed — happy to iterate!